### PR TITLE
Fix PHP timezone substitution

### DIFF
--- a/includes/php.ini
+++ b/includes/php.ini
@@ -976,7 +976,7 @@ cli_server.color = On
 [Date]
 ; Defines the default timezone used by the date functions
 ; https://php.net/date.timezone
-;date.timezone = TIME_ZONE
+date.timezone = MYTIMEZONE
 
 ; https://php.net/date.default-latitude
 ;date.default_latitude = 31.7667

--- a/sample.conf
+++ b/sample.conf
@@ -3,7 +3,7 @@ FREEBSD_REPO="latest"                                # Set repository for FreeBS
 HOST_NAME="nextcloud.my.network"                     # Hostname for the server
 IP_ADDRESS="IP_ADDRESS_VALUE"                        # IP address of the server
 COUNTRY_CODE="XW"                                    # Example: AU/CA/DE/FR/UK/US/ZA, etc.
-TIME_ZONE="Etc/GMT"                                  # See: https://www.php.net/manual/en/timezones.php
+TIME_ZONE="UTC"                                      # See: https://www.php.net/manual/en/timezones.php
 WWW_DIR="/usr/local/www"                             # NOTE: no trailing /
 
 # Email settings


### PR DESCRIPTION
Fixes the missing placeholder in php.ini.

Also, changes the default timezone to UTC as per https://www.php.net/manual/en/datetime.configuration.php#ini.date.timezone .