### PR TITLE
Reduce PHP opcache JIT buffer

### DIFF
--- a/includes/php.ini
+++ b/includes/php.ini
@@ -1916,7 +1916,7 @@ opcache.save_comments=1
 ;opcache.huge_code_pages=0
 
 opcache.jit = 1255
-opcache.jit_buffer_size = 128M
+opcache.jit_buffer_size = 8M
 
 ; Validate cached file permissions.
 ;opcache.validate_permission=0


### PR DESCRIPTION
> Single Nextcloud instances have shown to use less than 2 MiB of the configured JIT buffer size, so that 8 MiB is sufficient by a large margin.

https://docs.nextcloud.com/server/latest/admin_manual/installation/server_tuning.html#jit