### PR TITLE
Fix MariaDB warnings

### DIFF
--- a/includes/my.cnf
+++ b/includes/my.cnf
@@ -36,8 +36,7 @@ default-character-set=utf8mb4
 character_set_server=utf8mb4
 collation_server=utf8mb4_general_ci
 transaction_isolation=READ-COMMITTED
+log_bin=1
 binlog_format=ROW
-innodb_large_prefix=on
-innodb_file_format=barracuda
 innodb_file_per_table=1
 skip-innodb_doublewrite


### PR DESCRIPTION
This PR removes the following warnings in MariaDB error logs:

```
[Warning] You need to use --log-bin to make --binlog-format work.
[Warning] 'innodb-large-prefix' was removed. It does nothing now and exists only for compatibility with old my.cnf files.
[Warning] 'innodb-file-format' was removed. It does nothing now and exists only for compatibility with old my.cnf files.
```

P.S. I'm using 10.11 but assume it will be the same in newer versions.