### PR TITLE
Configure SSL session cache

### DIFF
--- a/includes/httpd.conf
+++ b/includes/httpd.conf
@@ -29,6 +29,7 @@ LoadModule autoindex_module libexec/apache24/mod_autoindex.so
 LoadModule dir_module libexec/apache24/mod_dir.so
 LoadModule alias_module libexec/apache24/mod_alias.so
 LoadModule rewrite_module libexec/apache24/mod_rewrite.so
+LoadModule socache_shmcb_module libexec/apache24/mod_socache_shmcb.so
 
 <IfModule php_module>
    <FilesMatch "\.(php|phps|php8|phtml)$">
@@ -114,6 +115,8 @@ Include etc/apache24/extra/proxy-html.conf
 </IfModule>
 
 <IfModule ssl_module>
+SSLSessionCache "shmcb:/var/run/ssl_scache(512000)"
+SSLSessionCacheTimeout 300
 SSLRandomSeed startup builtin
 SSLRandomSeed connect builtin
 </IfModule>


### PR DESCRIPTION
This PR fixes an Apache warning:

```
[ssl:warn] [pid xxxx:tid xxxx] AH01873: Init: Session Cache is not configured [hint: SSLSessionCache]
```